### PR TITLE
Correction in README.md (Globablly -> Globally)

### DIFF
--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -43,7 +43,7 @@ with NPM 5.5.1 or higher.
 
 **BEFORE YOU INSTALL:** please read the [prerequisites](#prerequisites)
 
-### Install Globablly
+### Install Globally
 ```bash
 npm install -g @angular/cli
 ```


### PR DESCRIPTION
Replaced "Globablly" with correct word "Globally" under Installation section.